### PR TITLE
Expose the hotswap function for easier maintainability

### DIFF
--- a/assets/_reactor/core.js
+++ b/assets/_reactor/core.js
@@ -4,10 +4,9 @@
 // This is done at build time in Setup.hs.
 
 // Options:
-// Attempt to set up a socket to the server
-// options.socket = boolean
-// Show the hotswap button
-// options.hotswapButton = boolean
+
+// Expose internal hotswap function, disable hotswap button, no socket
+// options.externalHotswap = boolean
 
 ElmRuntime.debugFullscreenWithOptions = function(options) {
 
@@ -21,7 +20,7 @@ ElmRuntime.debugFullscreenWithOptions = function(options) {
 
         var mainHandle = Elm.fullscreenDebugHooks(module, hotSwapState);
         var debuggerHandle = initDebugger();
-        if (!options.debugElmLangOrg) {
+        if (!options.externalHotswap) {
             initSocket();
         }
 
@@ -133,7 +132,7 @@ ElmRuntime.debugFullscreenWithOptions = function(options) {
             var handle = Elm.embed(Elm.DebuggerInterface, debuggerDiv,
                 { eventCounter: 0,
                   watches: [],
-                  showHotswap: !options.debugElmLangOrg
+                  showHotswap: !options.externalHotswap
                 });
             handle.ports.scrubTo.subscribe(scrubber);
             handle.ports.pause.subscribe(elmPauser);
@@ -217,7 +216,7 @@ ElmRuntime.debugFullscreenWithOptions = function(options) {
             }
         }
 
-        if (!options.debugElmLangOrg) {
+        if (!options.externalHotswap) {
             mainHandle.debugger.hotSwap = hotSwap;
         }
         return mainHandle;

--- a/assets/_reactor/reactor.js
+++ b/assets/_reactor/reactor.js
@@ -3,5 +3,5 @@
 // javascript, toString.js, and debug-core.js. This is done at build time in Setup.hs
 
 Elm.debugFullscreen = ElmRuntime.debugFullscreenWithOptions({
-    debugElmLangOrg: false
+    externalHotswap: false
 });


### PR DESCRIPTION
We need another option for elm-debugger. We shouldn't have two copies of the hot swap function when they do the same thing in both the reactor and on debug.elm-lang.org.

We only need to expose this internal function when we're on debug.elm-lang.org.

After this, I can't think of anything else stopped me from finished the import of the new debugger into the debug.elm-lang.org repo.
