### PR TITLE
Debug scroll bar

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -16,15 +16,17 @@ main = defaultMainWithHooks simpleUserHooks { postBuild = myPostBuild }
 
 myPostBuild :: Args -> BuildFlags -> PackageDescription -> LocalBuildInfo -> IO ()
 myPostBuild args flags pd lbi =
-    do putStrLn "Custom build step: compiling debuggerInterface.elm"
-       buildInterface lbi
+    do putStrLn "Custom build step: compiling sliderInterface.elm and watchesInterface.elm"
+       buildSliderInterface lbi
+       buildWatchesInterface lbi
        concatJS lbi
        postBuild simpleUserHooks args flags pd lbi
 
 concatJS :: LocalBuildInfo -> IO ()
 concatJS lbi =
   do let files = map (("assets" </> "_reactor") </>)
-          [ "debuggerInterface.js"
+          [ "watchesInterface.js"
+          , "sliderInterface.js"
           , "toString.js"
           , "core.js"
           , "reactor.js"
@@ -33,19 +35,55 @@ concatJS lbi =
      _ <- putStrLn "Writing composite debugger.js"
      writeFile ("assets" </> "debugger.js") megaJS
 
-buildInterface :: LocalBuildInfo -> IO ()
-buildInterface lbi =
-    do exitCode <- compile $ args "debuggerInterface.elm"
+buildSliderInterface :: LocalBuildInfo -> IO ()
+buildSliderInterface lbi =
+    do exitCode <- compile $ args "sliderInterface.elm"
        case exitCode of
             ExitFailure _ ->
-                putStrLn "Build failed: debuggerInterface"
+                putStrLn "Build failed: sliderInterface"
             ExitSuccess ->
                 renameFile
-                    ("slider" </> "build" </> "debuggerInterface.js")
-                    ("assets" </> "_reactor" </> "debuggerInterface.js")
+                    ("slider" </> "build" </> "sliderInterface.js")
+                    ("assets" </> "_reactor" </> "sliderInterface.js")
 
        removeEverything "slider" "Slider.elm"
-       removeEverything "slider" "debuggerInterface.elm"
+       removeEverything "slider" "sliderInterface.elm"
+    where
+        args file =
+            [ "--make"
+            , "--only-js"
+            , file
+            ]
+
+        compile args =
+            do let workingDir = Just "slider"
+               handle <- runProcess "elm" args workingDir Nothing Nothing Nothing Nothing
+               exitCode <- waitForProcess handle
+               return exitCode
+
+        removeEverything dir file =
+            do remove "cache" "elmi"
+               remove "cache" "elmo"
+               remove "build" "js"
+            where
+                remove :: String -> String -> IO ()
+                remove subdir ext =
+                    do let path = dir </> subdir </> file`replaceExtension` ext
+                       exists <- doesFileExist path
+                       when exists (removeFile path)
+
+buildWatchesInterface :: LocalBuildInfo -> IO ()
+buildWatchesInterface lbi =
+    do exitCode <- compile $ args "watchesInterface.elm"
+       case exitCode of
+            ExitFailure _ ->
+                putStrLn "Build failed: watchesInterface"
+            ExitSuccess ->
+                renameFile
+                    ("slider" </> "build" </> "watchesInterface.js")
+                    ("assets" </> "_reactor" </> "watchesInterface.js")
+
+       removeEverything "slider" "watchesInterface.elm"
     where
         args file =
             [ "--make"

--- a/assets/_reactor/core.js
+++ b/assets/_reactor/core.js
@@ -19,7 +19,9 @@ ElmRuntime.debugFullscreenWithOptions = function(options) {
         var ELM_LIGHT_GREY = "#E4E4E4";
 
         var mainHandle = Elm.fullscreenDebugHooks(module, swapState);
-        var debuggerHandle = initDebugger();
+        var debuggerHandles = initDebugger();
+        var watchesHandle = debuggerHandles[0];
+        var sliderHandle = debuggerHandles[1];
         if (!options.externalSwap) {
             initSocket();
         }
@@ -27,8 +29,8 @@ ElmRuntime.debugFullscreenWithOptions = function(options) {
         parent.window.addEventListener("message", function(e) {
             if (e.data === "elmNotify") {
                 var currentPosition = mainHandle.debugger.getMaxSteps();
-                if (debuggerHandle.ports) {
-                    debuggerHandle.ports.eventCounter.send(currentPosition);
+                if (sliderHandle.ports) {
+                    sliderHandle.ports.eventCounter.send(currentPosition);
                     sendWatches(currentPosition);
                 }
             }
@@ -36,16 +38,26 @@ ElmRuntime.debugFullscreenWithOptions = function(options) {
 
         function createDebuggingElement() {
             var debuggingPanelExpanded = true;
-            var debuggerWidth = 275;
+            var debuggerWidth = 295;
 
             var debugTools = document.createElement("div");
             debugTools.id = ELM_DEBUGGER_ID;
 
+            var watchesDiv = document.createElement("div");
+            watchesDiv.id = "elmWatches";
+            watchesDiv.style.overflowY = "auto";
+            watchesDiv.style.overflowX = "hidden";
+            watchesDiv.style.height = "calc(100% - 150px)";
+
+            var sliderDiv = document.createElement("div");
+            sliderDiv.id = "elmSlider";
+
             var debuggerDiv = document.createElement("div");
             debuggerDiv.id = "elmDebugger";
             debuggerDiv.style.overflow = "hidden";
-            debuggerDiv.style.overflowY = "auto";
             debuggerDiv.style.height = "100%";
+            debuggerDiv.appendChild(sliderDiv);
+            debuggerDiv.appendChild(watchesDiv);
 
             // Create and style the panel
             debugTools.style.background = ELM_DARK_GREY;
@@ -129,18 +141,23 @@ ElmRuntime.debugFullscreenWithOptions = function(options) {
 
             var debugTools = createDebuggingElement();
             document.body.appendChild(debugTools);
-            var debuggerDiv = document.getElementById("elmDebugger");
+            var elmWatches = document.getElementById("elmWatches");
+            var watchesHandle = Elm.embed(Elm.WatchesInterface, elmWatches,
+                { watches: []
+                });
 
-            var handle = Elm.embed(Elm.DebuggerInterface, debuggerDiv,
+            var elmSlider = document.getElementById("elmSlider");
+            var slideHandle = Elm.embed(Elm.SliderInterface, elmSlider,
                 { eventCounter: 0,
-                  watches: [],
                   showSwap: !options.externalSwap
                 });
-            handle.ports.scrubTo.subscribe(scrubber);
-            handle.ports.pause.subscribe(elmPauser);
-            handle.ports.restart.subscribe(elmRestart);
-            handle.ports.permitSwap.subscribe(elmSwap);
-            return handle;
+            slideHandle.ports.scrubTo.subscribe(scrubber);
+            slideHandle.ports.pause.subscribe(elmPauser);
+            slideHandle.ports.restart.subscribe(elmRestart);
+            slideHandle.ports.permitSwap.subscribe(elmSwap);
+
+
+            return [watchesHandle,slideHandle];
         }
 
         function sendWatches(position) {
@@ -156,7 +173,7 @@ ElmRuntime.debugFullscreenWithOptions = function(options) {
                 var stringified = prettyPrint(value, separator);
                 output.push([key, stringified]);
             }
-            debuggerHandle.ports.watches.send(output);
+            watchesHandle.ports.watches.send(output);
         }
 
         function initSocket() {

--- a/slider/sliderInterface.elm
+++ b/slider/sliderInterface.elm
@@ -1,4 +1,4 @@
-module DebuggerInterface where
+module SliderInterface where
 
 import Window
 import Graphics.Input (..)
@@ -49,12 +49,6 @@ dataStyle typefaces height string =
 
 textStyle : String -> Text
 textStyle = dataStyle ["Gotham", "Futura", "Lucida Grande", "sans-serif"] 12
-
-watchStyle : String -> Text
-watchStyle = dataStyle ["Gotham", "Futura", "Lucida Grande", "sans-serif"] 14
-
-codeStyle : String -> Text
-codeStyle = dataStyle ["Menlo for Powerline", "monospace"] 12
 
 --
 -- View
@@ -155,8 +149,8 @@ sliderMinMaxText w state =
             , sliderTotalEvents
             ]
 
-view : (Int, Int) -> [(String, String)] -> Bool -> State -> Element
-view (w,h) watches permitSwap state =
+controlView : (Int, Int) -> Bool -> State -> Element
+controlView (w, h) permitSwap state =
     let midWidth = w - sideMargin
         topSpacerHeight = 15
         buttonSliderSpaceHeight = 10
@@ -192,33 +186,16 @@ view (w,h) watches permitSwap state =
             [ spacer w 1 |> GE.color lightGrey |> opacity 0.3
             , spacer w 12
             ]
-        showWatch (k,v) = flow down
-            [ k |> watchStyle |> bold |> leftAligned |> width w
-            , v |> codeStyle |> leftAligned |> width w
-            , spacer 1 12
-            ]
-        watchView = flow right
-            [ spacer 20 1
-            , case watches of
-                [] -> noWatches
-                ws -> map showWatch ws |> flow down
-            ]
-    in  flow down
-            [ controls
-            , bar
-            , watchView
-            ]
-        
+    in flow down [ controls, bar ]
 
 --
 -- The wiring
 --
 
 main : Signal Element
-main = view <~ ((\(w, h) -> (panelWidth, h)) <~ Window.dimensions)
-             ~ watches
-             ~ permitSwapInput.signal
-             ~ scene
+main = controlView <~ ((\(w, h) -> (panelWidth, h)) <~ Window.dimensions)
+                    ~ permitSwapInput.signal
+                    ~ scene
 
 port scrubTo : Signal Int
 port scrubTo = .scrubPosition <~ scene
@@ -245,8 +222,6 @@ scrubInput : Input Int
 scrubInput = input 0
 
 port eventCounter : Signal Int
-
-port watches : Signal [(String, String)]
 
 port showSwap : Bool
 
@@ -310,26 +285,5 @@ roundedSquare side radius toForm =
         br = formedCircle |> move ( circleOffset,-circleOffset)
     in
         group [xRect, yRect, tl, tr, bl, br]
-
-
---
--- Copy
---
-
-noWatches : Element
-noWatches = [markdown|
-
-### <span style="font-family: Gotham, Futura, 'Lucida Grande', sans-serif; font-size: 12pt; color: rgb(170,170,170)"> You don't have any watches! </span>
-
-<span style="color: rgb(170,170,170)">
-<span style="font-family: Gotham, Futura, 'Lucida Grande', sans-serif; font-size: 10pt; color: rgb(170,170,170)">
-Use [<span style="text-decoration:underline; color: rgb(170,170,170)">Debug.watch</span>](http://library.elm-lang.org/catalog/elm-lang-Elm/latest/Debug#watch)
-to show any value. <br>
-`watch : String -> a -> a`</span>
-
-<span style="font-family: Gotham, Futura, 'Lucida Grande', sans-serif; font-size: 10pt; color: rgb(170,170,170)">
-Use [<span style="text-decoration:underline; color: rgb(170,170,170)">Debug.watchSummary</span>](http://library.elm-lang.org/catalog/elm-lang-Elm/latest/Debug#watchSummary) to show a <br>
-summary or subvalue of any value. </span><br>
-|]
 
 

--- a/slider/watchesInterface.elm
+++ b/slider/watchesInterface.elm
@@ -1,0 +1,79 @@
+module WatchesInterface where
+
+import Window
+import Text (..)
+
+-- Style
+--
+
+panelWidth = 275
+
+dataStyle : [String] -> Float -> String -> Text
+dataStyle typefaces height string =
+    let myStyle =
+             { defaultStyle
+             | typeface <- typefaces
+             , color <- lightGrey
+             , height <- Just height
+             }
+    in
+        style myStyle (toText string)
+
+watchStyle : String -> Text
+watchStyle = dataStyle ["Gotham", "Futura", "Lucida Grande", "sans-serif"] 14
+
+codeStyle : String -> Text
+codeStyle = dataStyle ["Menlo for Powerline", "monospace"] 12
+
+--
+-- View
+--
+
+watchView : (Int, Int) -> [(String, String)] -> Element
+watchView (w, h) watches = 
+    let showWatch (k,v) = flow down
+            [ k |> watchStyle |> bold |> leftAligned |> width w
+            , v |> codeStyle |> leftAligned |> width w
+            , spacer 1 12
+            ]
+
+        watchView = flow right
+            [ spacer 20 1
+            , case watches of
+                [] -> noWatches
+                ws -> map showWatch ws |> flow down
+            ]
+    in watchView
+
+
+--
+-- The wiring
+--
+
+main : Signal Element
+main = watchView <~ ((\(w, h) -> (panelWidth, h)) <~ Window.dimensions)
+                  ~ watches
+
+port watches : Signal [(String, String)]
+
+--
+-- Copy
+--
+
+noWatches : Element
+noWatches = [markdown|
+
+### <span style="font-family: Gotham, Futura, 'Lucida Grande', sans-serif; font-size: 12pt; color: rgb(170,170,170)"> You don't have any watches! </span>
+
+<span style="color: rgb(170,170,170)">
+<span style="font-family: Gotham, Futura, 'Lucida Grande', sans-serif; font-size: 10pt; color: rgb(170,170,170)">
+Use [<span style="text-decoration:underline; color: rgb(170,170,170)">Debug.watch</span>](http://library.elm-lang.org/catalog/elm-lang-Elm/latest/Debug#watch)
+to show any value. <br>
+`watch : String -> a -> a`</span>
+
+<span style="font-family: Gotham, Futura, 'Lucida Grande', sans-serif; font-size: 10pt; color: rgb(170,170,170)">
+Use [<span style="text-decoration:underline; color: rgb(170,170,170)">Debug.watchSummary</span>](http://library.elm-lang.org/catalog/elm-lang-Elm/latest/Debug#watchSummary) to show a <br>
+summary or subvalue of any value. </span><br>
+|]
+
+


### PR DESCRIPTION
To make this work, I decoupled the Watches and the Scroll Bar into two different elm programs each which uses the correct ports. I then updated core.js to use the correct handler.

This adds a scroll bar to the watches section such that you can scroll through them and still see the time travelling / swap options.

This resolves https://github.com/elm-lang/elm-reactor/issues/29. Tested in chrome and firefox.
