### PR TITLE
Iron out some display quirks

### DIFF
--- a/assets/_reactor/core.js
+++ b/assets/_reactor/core.js
@@ -48,14 +48,13 @@ function debugFullscreenWithOptions(options) {
             // Create and style the panel
             debugTools.style.background = ELM_DARK_GREY;
             debugTools.style.width = debuggerWidth + "px";
-            debugTools.style.height = "100%";
+            debugTools.style.minHeight = "100%";
             debugTools.style.position = "absolute";
             debugTools.style.top = "0px";
             debugTools.style.right = "0px";
             debugTools.style.transitionDuration = "0.3s";
             debugTools.style.opacity = 0.90;
             debugTools.style.zIndex = 1000;
-            debugToolw.style.overflow = 'auto';
 
             // Prevent clicks from reaching the main elm instance under the panel
             function stopEvents(e) {

--- a/assets/_reactor/core.js
+++ b/assets/_reactor/core.js
@@ -53,8 +53,9 @@ function debugFullscreenWithOptions(options) {
             debugTools.style.top = "0px";
             debugTools.style.right = "0px";
             debugTools.style.transitionDuration = "0.3s";
-            debugTools.style.opacity = 0.97;
-            debugTools.style.zIndex = 1;
+            debugTools.style.opacity = 0.90;
+            debugTools.style.zIndex = 1000;
+            debugToolw.style.overflow = 'auto';
 
             // Prevent clicks from reaching the main elm instance under the panel
             function stopEvents(e) {


### PR DESCRIPTION
1) `zIndex` of `1` isn't enough for sites that use `zIndex` extensively (e.g. bootstrap).
2) `minHeight` is needed when there's too much watches or data. This fixes "white-on-white" text flowing out of the debugger panel.
3) A little more transparency wouldn't hurt debugger visibility but will help with that's behind it.