### PR TITLE
Allow client to initialize some input ports when debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ That creates the `Elm.debugFullscreen` function so you can initiate your Elm
 program with the debugger:
 
 ```javascript
-var runningElmModule = Elm.debugFullscreen(Elm.Todo, "todo.elm");
+var runningElmModule = Elm.debugFullscreen(Elm.Todo, {}, "todo.elm");
 ```
 
 The argument `"todo.elm"` is the file path to the root module of your project,

--- a/backend/Compile.hs
+++ b/backend/Compile.hs
@@ -120,5 +120,5 @@ initialize debug name filePath =
   in
       "var runningElmModule =\n    " ++
       case debug of
-        True -> "Elm.debugFullscreen(" ++ moduleName ++ ", \"" ++ filePath ++ "\");"
-        False -> "Elm.fullscreen(" ++ moduleName ++ ");"
+        True -> "Elm.debugFullscreen(" ++ moduleName ++ ", {}, \"" ++ filePath ++ "\");"
+        False -> "Elm.fullscreen(" ++ moduleName ++ ", {});"

--- a/frontend/core.js
+++ b/frontend/core.js
@@ -9,7 +9,7 @@
 
 function debugFullscreenWithOptions(options) {
 
-    return function(elmModule, elmModuleFile, swapState /* =undefined */) {
+    return function(elmModule, ports, elmModuleFile, swapState /* =undefined */) {
         var createdSocket = false;
         var elmPermitSwaps = true;
 
@@ -17,7 +17,7 @@ function debugFullscreenWithOptions(options) {
         var ELM_DARK_GREY = "#4A4A4A";
         var ELM_LIGHT_GREY = "#E4E4E4";
 
-        var mainHandle = Elm.fullscreenDebugHooks(elmModule, swapState);
+        var mainHandle = Elm.fullscreenDebugHooks(elmModule, ports, swapState);
         var debuggerHandle = initDebugger();
         if (!options.externalSwap) {
             initSocket();
@@ -190,7 +190,7 @@ function debugFullscreenWithOptions(options) {
                     mainHandle.debugger.dispose();
                     mainHandle.dispose();
 
-                    mainHandle = Elm.fullscreenDebugHooks(elmModule, debuggerState);
+                    mainHandle = Elm.fullscreenDebugHooks(elmModule, ports, debuggerState);
 
                     // The div that rejects events must be after Elm
                     var ignoringDiv = document.getElementById("elmEventIgnorer");

--- a/frontend/debug.js
+++ b/frontend/debug.js
@@ -8,7 +8,7 @@ if (typeof window != 'undefined' && !window.location.origin) {
       (window.location.port ? (':' + window.location.port) : '');
 }
 
-Elm.fullscreenDebugHooks = function(elmModule, debuggerHistory /* =undefined */) {
+Elm.fullscreenDebugHooks = function(elmModule, ports, debuggerHistory /* =undefined */) {
   var exposedDebugger = {};
   function debuggerAttach(elmModule, debuggerHistory) {
     return {
@@ -19,7 +19,7 @@ Elm.fullscreenDebugHooks = function(elmModule, debuggerHistory /* =undefined */)
       }
     }
   }
-  var mainHandle = Elm.fullscreen(debuggerAttach(elmModule, debuggerHistory));
+  var mainHandle = Elm.fullscreen(debuggerAttach(elmModule, debuggerHistory), ports);
   mainHandle.debugger = exposedDebugger;
   return mainHandle;
 };


### PR DESCRIPTION
This small change gives the client the ability to manually initialize some input ports before firing up `debugFullscreen` similar to how `fullscreen` works on regular elm modules. I hope this will contribute a small step towards closing #36. It is *only* intended for initialization of ports. Never-the-less this makes it possible to debug many (most?) embedded widgets which are impossible to debug right now.