### PR TITLE
Bump elm-html version, so that apps that depend on it don't get an old version

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -10,7 +10,7 @@
     "native-modules": true,
     "dependencies": {
         "elm-lang/core": "1.0.0 <= v < 2.0.0",
-        "evancz/elm-html": "1.0.0 <= v < 2.0.0",
+        "evancz/elm-html": "2.0.0 <= v < 3.0.0",
         "evancz/elm-markdown": "1.0.0 <= v < 2.0.0"
     }
 }


### PR DESCRIPTION
This was resulting in an inscrutable error about trying to get 'arity' of 'undefined' (namely, VirtualDom.Attribute) in my code.

I haven't noticed any breakages from doing this, but I can't tell for sure.

