### PR TITLE
Updates for 0.15

### DIFF
--- a/frontend/SideBar.elm
+++ b/frontend/SideBar.elm
@@ -1,6 +1,6 @@
 module SideBar where
 
-import Graphics.Element (..)
+import Graphics.Element exposing (..)
 import Html
 import List
 import Signal

--- a/frontend/SideBar.elm
+++ b/frontend/SideBar.elm
@@ -31,7 +31,7 @@ main =
   Signal.map4 view
     (Signal.map (\(w,h) -> (Controls.panelWidth, h)) Window.dimensions)
     watches
-    Controls.permitSwapMailbox.signal
+    permitSwapMailbox.signal
     scene
 
 
@@ -43,12 +43,21 @@ scene =
 aggregateUpdates : Signal Model.Action
 aggregateUpdates =
   Signal.mergeMany
-    [ Signal.map (always Model.Restart) Controls.restartMailbox.signal
-    , Signal.map Model.Pause Controls.pausedInput.signal
+    [ Signal.map (always Model.Restart) restartMailbox.signal
+    , Signal.map Model.Pause pausedInputMailbox.signal
     , Signal.map Model.TotalEvents eventCounter
-    , Signal.map Model.ScrubPosition Controls.scrubMailbox.signal
+    , Signal.map Model.ScrubPosition scrubMailbox.signal
     ]
 
+-- CONTROL MAILBOXES
+
+permitSwapMailbox = Controls.permitSwapMailbox
+
+restartMailbox = Controls.restartMailbox
+
+pausedInputMailbox = Controls.pausedInputMailbox
+
+scrubMailbox = Controls.scrubMailbox
 
 -- INCOMING PORTS
 
@@ -63,19 +72,19 @@ port showSwap : Bool
 
 port scrubTo : Signal Int
 port scrubTo =
-    Controls.scrubMailbox.signal
+    scrubMailbox.signal
 
 
 port pause : Signal Bool
 port pause =
-    Controls.pausedInput.signal
+    pausedInputMailbox.signal
 
 
 port restart : Signal Int
 port restart =
-    Signal.map (always 0) Controls.restartMailbox.signal
+    Signal.map (always 0) restartMailbox.signal
 
 
 port permitSwap : Signal Bool
 port permitSwap =
-    Controls.permitSwapMailbox.signal
+    permitSwapMailbox.signal

--- a/frontend/SideBar.elm
+++ b/frontend/SideBar.elm
@@ -31,7 +31,7 @@ main =
   Signal.map4 view
     (Signal.map (\(w,h) -> (Controls.panelWidth, h)) Window.dimensions)
     watches
-    (Signal.subscribe Controls.permitSwapChannel)
+    Controls.permitSwapMailbox.signal
     scene
 
 
@@ -43,10 +43,10 @@ scene =
 aggregateUpdates : Signal Model.Action
 aggregateUpdates =
   Signal.mergeMany
-    [ Signal.map (always Model.Restart) (Signal.subscribe Controls.restartChannel)
-    , Signal.map Model.Pause (Signal.subscribe Controls.pausedInput)
+    [ Signal.map (always Model.Restart) Controls.restartMailbox.signal
+    , Signal.map Model.Pause Controls.pausedInput.signal
     , Signal.map Model.TotalEvents eventCounter
-    , Signal.map Model.ScrubPosition (Signal.subscribe Controls.scrubChannel)
+    , Signal.map Model.ScrubPosition Controls.scrubMailbox.signal
     ]
 
 
@@ -63,19 +63,19 @@ port showSwap : Bool
 
 port scrubTo : Signal Int
 port scrubTo =
-    Signal.subscribe Controls.scrubChannel
+    Controls.scrubMailbox.signal
 
 
 port pause : Signal Bool
 port pause =
-    Signal.subscribe Controls.pausedInput
+    Controls.pausedInput.signal
 
 
 port restart : Signal Int
 port restart =
-    Signal.map (always 0) (Signal.subscribe Controls.restartChannel)
+    Signal.map (always 0) Controls.restartMailbox.signal
 
 
 port permitSwap : Signal Bool
 port permitSwap =
-    Signal.subscribe Controls.permitSwapChannel
+    Controls.permitSwapMailbox.signal

--- a/frontend/SideBar.elm
+++ b/frontend/SideBar.elm
@@ -3,7 +3,6 @@ module SideBar where
 import Graphics.Element exposing (..)
 import Html
 import List
-import Signal
 import Window
 
 import SideBar.Controls as Controls

--- a/frontend/SideBar/Controls.elm
+++ b/frontend/SideBar/Controls.elm
@@ -60,12 +60,12 @@ myButton message name =
 
 playButton : Element
 playButton =
-    myButton (Signal.send pausedInput False) "play"
+    myButton (Signal.message pausedInput.address False) "play"
 
 
 pauseButton : Element
 pauseButton =
-    myButton (Signal.send pausedInput True) "pause"
+    myButton (Signal.message pausedInput.address True) "pause"
 
 
 pausedInput : Signal.Mailbox Bool
@@ -75,7 +75,7 @@ pausedInput =
 
 restartButton : Element
 restartButton =
-    myButton (Signal.send restartSignal ()) "restart"
+    myButton (Signal.message restartSignal.address ()) "restart"
 
 
 restartSignal : Signal.Mailbox ()
@@ -115,12 +115,12 @@ swapButton permitSwap =
         button =
             case permitSwap of
               True ->
-                customButton (Signal.send permitSwapSignal False)
+                customButton (Signal.message permitSwapMailbox.address False)
                     (collage hsWidth hsWidth trueButton)
                     (collage hsWidth hsWidth trueButtonHover)
                     (collage hsWidth hsWidth trueButtonClick)
               False ->
-                customButton (Signal.send permitSwapSignal True)
+                customButton (Signal.message permitSwapMailbox.address True)
                     (collage hsWidth hsWidth falseButton)
                     (collage hsWidth hsWidth falseButtonHover)
                     (collage hsWidth hsWidth falseButtonClick)
@@ -130,8 +130,8 @@ swapButton permitSwap =
         flow right [ info, spacer 10 1, button ]
 
 
-permitSwapChannel : Signal.Mailbox Bool
-permitSwapChannel =
+permitSwapMailbox : Signal.Mailbox Bool
+permitSwapMailbox =
     Signal.mailbox True
 
 
@@ -146,12 +146,12 @@ scrubSlider (w,_) state =
                 value <- toFloat state.scrubPosition
             }
     in
-        slider (\n -> Signal.message scrubSignal.address (round n)) sliderStyle
+        slider (\n -> Signal.message scrubMailbox.address (round n)) sliderStyle
             |> container sliderLength 20 middle
 
 
-scrubChannel : Signal.Mailbox Int
-scrubChannel =
+scrubMailbox : Signal.Mailbox Int
+scrubMailbox =
     Signal.mailbox 0
 
 

--- a/frontend/SideBar/Controls.elm
+++ b/frontend/SideBar/Controls.elm
@@ -5,7 +5,7 @@ import Graphics.Collage exposing (..)
 import Graphics.Element as GE exposing (..)
 import Graphics.Input exposing (..)
 import List
-import Signal as Signal exposing (Signal, Message, Mailbox, (<~), (~), send, mailbox)
+import Signal as S exposing (Signal, (<~), (~))
 import Slider exposing (..)
 import Text
 
@@ -50,7 +50,7 @@ textStyle string =
 
 -- VIEW
 
-myButton : Message -> String -> Element
+myButton : Signal.Message -> String -> Element
 myButton message name =
     let img state =
           image 40 40 ("/_reactor/debugger/" ++ name ++ "-button-" ++ state ++ ".png")
@@ -60,27 +60,27 @@ myButton message name =
 
 playButton : Element
 playButton =
-    myButton (send pausedInput False) "play"
+    myButton (Signal.send pausedInput False) "play"
 
 
 pauseButton : Element
 pauseButton =
-    myButton (send pausedInput True) "pause"
+    myButton (Signal.send pausedInput True) "pause"
 
 
-pausedInput : Mailbox Bool
+pausedInput : Signal.Mailbox Bool
 pausedInput =
-    mailbox False
+    Signal.mailbox False
 
 
 restartButton : Element
 restartButton =
-    myButton (send restartMailbox ()) "restart"
+    myButton (Signal.send restartSignal ()) "restart"
 
 
-restartMailbox : Mailbox ()
-restartMailbox =
-    mailbox ()
+restartSignal : Signal.Mailbox ()
+restartSignal =
+    Signal.mailbox ()
 
 
 swapButton : Bool -> Element
@@ -115,12 +115,12 @@ swapButton permitSwap =
         button =
             case permitSwap of
               True ->
-                customButton (send permitSwapMailbox False)
+                customButton (Signal.send permitSwapSignal False)
                     (collage hsWidth hsWidth trueButton)
                     (collage hsWidth hsWidth trueButtonHover)
                     (collage hsWidth hsWidth trueButtonClick)
               False ->
-                customButton (send permitSwapMailbox True)
+                customButton (Signal.send permitSwapSignal True)
                     (collage hsWidth hsWidth falseButton)
                     (collage hsWidth hsWidth falseButtonHover)
                     (collage hsWidth hsWidth falseButtonClick)
@@ -130,8 +130,9 @@ swapButton permitSwap =
         flow right [ info, spacer 10 1, button ]
 
 
-permitSwapMailbox : Mailbox Bool
-permitSwapMailbox = mailbox True
+permitSwapChannel : Signal.Mailbox Bool
+permitSwapChannel =
+    Signal.mailbox True
 
 
 scrubSlider : (Int, Int) -> Model.Model -> Element
@@ -145,12 +146,13 @@ scrubSlider (w,_) state =
                 value <- toFloat state.scrubPosition
             }
     in
-        slider (\n -> send scrubMailbox (round n)) sliderStyle
+        slider (\n -> Signal.message scrubSignal.address (round n)) sliderStyle
             |> container sliderLength 20 middle
 
 
-scrubMailbox : Mailbox Int
-scrubMailbox = mailbox 0
+scrubChannel : Signal.Mailbox Int
+scrubChannel =
+    Signal.mailbox 0
 
 
 sliderEventText : Int -> Model.Model -> Element

--- a/frontend/SideBar/Controls.elm
+++ b/frontend/SideBar/Controls.elm
@@ -1,14 +1,13 @@
 module SideBar.Controls where
 
 import Color
-import Graphics.Collage (..)
-import Graphics.Element (..)
-import Graphics.Element as GE
-import Graphics.Input (..)
+import Graphics.Collage exposing (..)
+import Graphics.Element as GE exposing (..)
+import Graphics.Input exposing (..)
 import List
 import Signal
-import Signal (Signal, (<~), (~))
-import Slider (..)
+import Signal exposing (Signal, (<~), (~))
+import Slider exposing (..)
 import Text
 
 import SideBar.Model as Model

--- a/frontend/SideBar/Controls.elm
+++ b/frontend/SideBar/Controls.elm
@@ -5,7 +5,7 @@ import Graphics.Collage exposing (..)
 import Graphics.Element as GE exposing (..)
 import Graphics.Input exposing (..)
 import List
-import Signal as Signal exposing (Signal, Message, (<~), (~), send)
+import Signal as Signal exposing (Signal, Message, Mailbox, (<~), (~), send, mailbox)
 import Slider exposing (..)
 import Text
 
@@ -68,19 +68,19 @@ pauseButton =
     myButton (send pausedInput True) "pause"
 
 
-pausedInput : Signal.Channel Bool
+pausedInput : Mailbox Bool
 pausedInput =
-    Signal.channel False
+    mailbox False
 
 
 restartButton : Element
 restartButton =
-    myButton (send restartChannel ()) "restart"
+    myButton (send restartMailbox ()) "restart"
 
 
-restartChannel : Signal.Channel ()
-restartChannel =
-    Signal.channel ()
+restartMailbox : Mailbox ()
+restartMailbox =
+    mailbox ()
 
 
 swapButton : Bool -> Element
@@ -115,12 +115,12 @@ swapButton permitSwap =
         button =
             case permitSwap of
               True ->
-                customButton (send permitSwapChannel False)
+                customButton (send permitSwapMailbox False)
                     (collage hsWidth hsWidth trueButton)
                     (collage hsWidth hsWidth trueButtonHover)
                     (collage hsWidth hsWidth trueButtonClick)
               False ->
-                customButton (send permitSwapChannel True)
+                customButton (send permitSwapMailbox True)
                     (collage hsWidth hsWidth falseButton)
                     (collage hsWidth hsWidth falseButtonHover)
                     (collage hsWidth hsWidth falseButtonClick)
@@ -130,9 +130,8 @@ swapButton permitSwap =
         flow right [ info, spacer 10 1, button ]
 
 
-permitSwapChannel : Signal.Channel Bool
-permitSwapChannel =
-    Signal.channel True
+permitSwapMailbox : Mailbox Bool
+permitSwapMailbox = mailbox True
 
 
 scrubSlider : (Int, Int) -> Model.Model -> Element
@@ -146,13 +145,12 @@ scrubSlider (w,_) state =
                 value <- toFloat state.scrubPosition
             }
     in
-        slider (\n -> send scrubChannel (round n)) sliderStyle
+        slider (\n -> send scrubMailbox (round n)) sliderStyle
             |> container sliderLength 20 middle
 
 
-scrubChannel : Signal.Channel Int
-scrubChannel =
-    Signal.channel 0
+scrubMailbox : Mailbox Int
+scrubMailbox = mailbox 0
 
 
 sliderEventText : Int -> Model.Model -> Element

--- a/frontend/SideBar/Controls.elm
+++ b/frontend/SideBar/Controls.elm
@@ -60,26 +60,26 @@ myButton message name =
 
 playButton : Element
 playButton =
-    myButton (Signal.message pausedInput.address False) "play"
+    myButton (Signal.message pausedInputMailbox.address False) "play"
 
 
 pauseButton : Element
 pauseButton =
-    myButton (Signal.message pausedInput.address True) "pause"
+    myButton (Signal.message pausedInputMailbox.address True) "pause"
 
 
-pausedInput : Signal.Mailbox Bool
-pausedInput =
+pausedInputMailbox : Signal.Mailbox Bool
+pausedInputMailbox =
     Signal.mailbox False
 
 
 restartButton : Element
 restartButton =
-    myButton (Signal.message restartSignal.address ()) "restart"
+    myButton (Signal.message restartMailbox.address ()) "restart"
 
 
-restartSignal : Signal.Mailbox ()
-restartSignal =
+restartMailbox : Signal.Mailbox ()
+restartMailbox =
     Signal.mailbox ()
 
 

--- a/frontend/SideBar/Controls.elm
+++ b/frontend/SideBar/Controls.elm
@@ -5,8 +5,7 @@ import Graphics.Collage exposing (..)
 import Graphics.Element as GE exposing (..)
 import Graphics.Input exposing (..)
 import List
-import Signal
-import Signal exposing (Signal, (<~), (~))
+import Signal as Signal exposing (Signal, Message, (<~), (~), send)
 import Slider exposing (..)
 import Text
 
@@ -51,7 +50,7 @@ textStyle string =
 
 -- VIEW
 
-myButton : Signal.Message -> String -> Element
+myButton : Message -> String -> Element
 myButton message name =
     let img state =
           image 40 40 ("/_reactor/debugger/" ++ name ++ "-button-" ++ state ++ ".png")
@@ -61,12 +60,12 @@ myButton message name =
 
 playButton : Element
 playButton =
-    myButton (Signal.send pausedInput False) "play"
+    myButton (send pausedInput False) "play"
 
 
 pauseButton : Element
 pauseButton =
-    myButton (Signal.send pausedInput True) "pause"
+    myButton (send pausedInput True) "pause"
 
 
 pausedInput : Signal.Channel Bool
@@ -76,7 +75,7 @@ pausedInput =
 
 restartButton : Element
 restartButton =
-    myButton (Signal.send restartChannel ()) "restart"
+    myButton (send restartChannel ()) "restart"
 
 
 restartChannel : Signal.Channel ()
@@ -116,12 +115,12 @@ swapButton permitSwap =
         button =
             case permitSwap of
               True ->
-                customButton (Signal.send permitSwapChannel False)
+                customButton (send permitSwapChannel False)
                     (collage hsWidth hsWidth trueButton)
                     (collage hsWidth hsWidth trueButtonHover)
                     (collage hsWidth hsWidth trueButtonClick)
               False ->
-                customButton (Signal.send permitSwapChannel True)
+                customButton (send permitSwapChannel True)
                     (collage hsWidth hsWidth falseButton)
                     (collage hsWidth hsWidth falseButtonHover)
                     (collage hsWidth hsWidth falseButtonClick)
@@ -147,7 +146,7 @@ scrubSlider (w,_) state =
                 value <- toFloat state.scrubPosition
             }
     in
-        slider (\n -> Signal.send scrubChannel (round n)) sliderStyle
+        slider (\n -> send scrubChannel (round n)) sliderStyle
             |> container sliderLength 20 middle
 
 

--- a/frontend/SideBar/Controls.elm
+++ b/frontend/SideBar/Controls.elm
@@ -125,7 +125,7 @@ swapButton permitSwap =
                     (collage hsWidth hsWidth falseButtonHover)
                     (collage hsWidth hsWidth falseButtonClick)
 
-        info = Text.leftAligned (textStyle "swap")
+        info = GE.leftAligned (textStyle "swap")
     in
         flow right [ info, spacer 10 1, button ]
 
@@ -179,7 +179,7 @@ sliderEventText w state =
         textPosition = middleAt xPos yPos
 
         text' =
-          Text.centered (textStyle (toString state.scrubPosition))
+          GE.centered (textStyle (toString state.scrubPosition))
     in
         container w textHeight textPosition text'
 
@@ -188,13 +188,13 @@ sliderMinMaxText : Int -> Model.Model -> Element
 sliderMinMaxText w state =
     let sliderStartText =
             textStyle "0"
-                |> Text.leftAligned
+                |> GE.leftAligned
                 |> container w textHeight topLeft
 
         sliderTotalEvents =
             toString state.totalEvents
                 |> textStyle
-                |> Text.rightAligned
+                |> GE.rightAligned
                 |> container w textHeight topRight
     in
         flow outward

--- a/frontend/SideBar/Controls.elm
+++ b/frontend/SideBar/Controls.elm
@@ -2,7 +2,7 @@ module SideBar.Controls where
 
 import Color
 import Graphics.Collage exposing (..)
-import Graphics.Element as GE exposing (..)
+import Graphics.Element exposing (..)
 import Graphics.Input exposing (..)
 import List
 import Signal as S exposing (Signal, (<~), (~))
@@ -125,7 +125,7 @@ swapButton permitSwap =
                     (collage hsWidth hsWidth falseButtonHover)
                     (collage hsWidth hsWidth falseButtonClick)
 
-        info = GE.leftAligned (textStyle "swap")
+        info = leftAligned (textStyle "swap")
     in
         flow right [ info, spacer 10 1, button ]
 
@@ -179,7 +179,7 @@ sliderEventText w state =
         textPosition = middleAt xPos yPos
 
         text' =
-          GE.centered (textStyle (toString state.scrubPosition))
+          centered (textStyle (toString state.scrubPosition))
     in
         container w textHeight textPosition text'
 
@@ -188,13 +188,13 @@ sliderMinMaxText : Int -> Model.Model -> Element
 sliderMinMaxText w state =
     let sliderStartText =
             textStyle "0"
-                |> GE.leftAligned
+                |> leftAligned
                 |> container w textHeight topLeft
 
         sliderTotalEvents =
             toString state.totalEvents
                 |> textStyle
-                |> GE.rightAligned
+                |> rightAligned
                 |> container w textHeight topRight
     in
         flow outward

--- a/frontend/SideBar/Watches.elm
+++ b/frontend/SideBar/Watches.elm
@@ -1,6 +1,6 @@
 module SideBar.Watches where
 
-import Html as Html exposing (..)
+import Html exposing (..)
 import Html.Attributes exposing (..)
 import Markdown
 

--- a/frontend/SideBar/Watches.elm
+++ b/frontend/SideBar/Watches.elm
@@ -1,8 +1,7 @@
 module SideBar.Watches where
 
-import Html
-import Html (..)
-import Html.Attributes (..)
+import Html as Html exposing (..)
+import Html.Attributes exposing (..)
 import List
 import Markdown
 

--- a/frontend/SideBar/Watches.elm
+++ b/frontend/SideBar/Watches.elm
@@ -2,7 +2,6 @@ module SideBar.Watches where
 
 import Html as Html exposing (..)
 import Html.Attributes exposing (..)
-import List as List exposing (map)
 import Markdown
 
 
@@ -11,7 +10,7 @@ view watches =
   div viewAttributes <|
       case watches of
         [] -> [noWatches]
-        _ -> map viewWatch watches
+        _ -> List.map viewWatch watches
 
 
 viewAttributes : List Attribute

--- a/frontend/SideBar/Watches.elm
+++ b/frontend/SideBar/Watches.elm
@@ -2,7 +2,7 @@ module SideBar.Watches where
 
 import Html as Html exposing (..)
 import Html.Attributes exposing (..)
-import List
+import List as List exposing (map)
 import Markdown
 
 
@@ -11,7 +11,7 @@ view watches =
   div viewAttributes <|
       case watches of
         [] -> [noWatches]
-        _ -> List.map viewWatch watches
+        _ -> map viewWatch watches
 
 
 viewAttributes : List Attribute

--- a/frontend/Slider.elm
+++ b/frontend/Slider.elm
@@ -11,7 +11,6 @@ module Slider where
 import Debug
 import Native.Slider
 import Graphics.Element exposing (Element)
-import Signal exposing (Message)
 
 {-| The attributes of a slider. This lets you customize a slider to fit however
 you want. You may also modify the default slider style with record updates.
@@ -68,5 +67,5 @@ meters with centimeter accuracy (0.01).
                   }
           in  slider age.handle id ageStyle
 -}
-slider : (Float -> Message) -> SliderStyle -> Element
+slider : (Float -> Signal.Message) -> SliderStyle -> Element
 slider = Native.Slider.slider

--- a/frontend/Slider.elm
+++ b/frontend/Slider.elm
@@ -11,7 +11,7 @@ module Slider where
 import Debug
 import Native.Slider
 import Graphics.Element exposing (Element)
-import Signal
+import Signal exposing (Message)
 
 {-| The attributes of a slider. This lets you customize a slider to fit however
 you want. You may also modify the default slider style with record updates.
@@ -68,5 +68,5 @@ meters with centimeter accuracy (0.01).
                   }
           in  slider age.handle id ageStyle
 -}
-slider : (Float -> Signal.Message) -> SliderStyle -> Element
+slider : (Float -> Message) -> SliderStyle -> Element
 slider = Native.Slider.slider

--- a/frontend/Slider.elm
+++ b/frontend/Slider.elm
@@ -10,7 +10,7 @@ module Slider where
 
 import Debug
 import Native.Slider
-import Graphics.Element (Element)
+import Graphics.Element exposing (Element)
 import Signal
 
 {-| The attributes of a slider. This lets you customize a slider to fit however


### PR DESCRIPTION
This makes some headway, but still does not compile.  I am now getting this issue:

```
Last 10 lines of the build log ( /home/sonny/.elmenv/elm-platform/installers/Elm-Platform/master/logs/elm-reactor-0.3.log ):
Building elm-reactor-0.3...
Preprocessing executable 'elm-reactor' for elm-reactor-0.3...
Failed to build SideBar.elm

your elm-package.json file says you depend on package evancz/elm-markdown,
but it looks like it is not properly installed. Try running 'elm-package install'.


Custom build step: creating and collecting all static resources
cabal: Error: some packages failed to install:
elm-reactor-0.3 failed during the building phase. The exception was:
ExitFailure 1
```

My initial guess is that there is no updated version of `elm-markdown` for 0.15 yet.  Would this make sense?