### PR TITLE
Use current debug state event time as 'now' if paused or swapping

### DIFF
--- a/frontend/debugger-implementation.js
+++ b/frontend/debugger-implementation.js
@@ -384,7 +384,7 @@ function jumpTo(index, debugState)
     while (debugState.index < index)
     {
         var event = debugState.events[debugState.index];
-        debugState.notify(event.id, event.value, event.time);
+        debugState.notify(event.id, event.value);
         debugState.index += 1;
     }
     redoTraces(debugState);
@@ -437,10 +437,9 @@ function transferState(previousDebugState, debugState)
     while (debugState.index < debugState.events.length)
     {
         var event = debugState.events[debugState.index];
-        debugState.index += 1;
         pushWatchFrame(debugState);
-
-        debugState.notify(event.id, event.value, event.time);
+        debugState.notify(event.id, event.value);
+        debugState.index += 1;
         snapshotIfNeeded(debugState);
     }
     redoTraces(debugState);
@@ -760,6 +759,11 @@ function initAndWrap(elmModule, runtime)
     var replace = Elm.Native.Utils.make(assignedPropTracker).replace;
 
     runtime.timer.now = function() {
+        if (debugState.paused || debugState.swapInProgress)
+        {
+            var event = debugState.events[debugState.index];
+            return event.time;
+        }
         return Date.now() - debugState.totalTimeLost;
     };
 


### PR DESCRIPTION
Fixes #87

Considered overriding `debugState.notify` to accept the timestep (like it may have done previously?) but that would require switching out the timer's `now` method in the overridden notify wrapper and that felt kinda gross.