### PR TITLE
changing default ip address to localhost from 0.0.0.0

### DIFF
--- a/backend/Main.hs
+++ b/backend/Main.hs
@@ -36,7 +36,7 @@ data Flags = Flags
 
 flags :: Flags
 flags = Flags
-  { bind = "0.0.0.0" &= help "set the host to bind to (default: 0.0.0.0)" &= typ "SPEC"
+  { bind = "localhost" &= help "set the host to bind to (default: localhost)" &= typ "SPEC"
   , port = 8000 &= help "set the port of the reactor (default: 8000)"
   } &= help "Interactive development tool that makes it easy to develop and debug Elm programs.\n\
             \    Read more about it at <https://github.com/elm-lang/elm-reactor>."


### PR DESCRIPTION
Hi,

elm-reactor's current default address is 0.0.0.0:8000 which is not a valid ip address and is not supported by chrome/ium. This fix changes the default address to localhost:8000.

related open bug: https://github.com/elm-lang/elm-reactor/issues/78

Thanks

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/elm-lang/elm-reactor/99)
<!-- Reviewable:end -->
