### PR TITLE
Skip signal children on output nodes

### DIFF
--- a/frontend/debugger-implementation.js
+++ b/frontend/debugger-implementation.js
@@ -721,7 +721,11 @@ function flattenSignalGraph(nodes)
 	function addAllToDict(node)
 	{
 		nodesById[node.id] = node;
-		node.kids.forEach(addAllToDict);
+
+		if (!node.isOutput)
+		{
+			node.kids.forEach(addAllToDict);
+		}
 	}
 	nodes.forEach(addAllToDict);
 


### PR DESCRIPTION
I have to confess I don't fully understand the signal stuff. But this appears to fix the #145 issue.

`elm-core` doesn't touch `kids` if it detects an output node (generally just returns). I'd suggest reactor should do the same.

closes #145