### PR TITLE
Ensure elm-reactor pages viewable on mobile

### DIFF
--- a/backend/Index.hs
+++ b/backend/Index.hs
@@ -110,6 +110,7 @@ elmIndexGenerator directory =
     writeBS "<title>"
     writeS title
     writeBS "</title>"
+    writeBs "<meta name='viewport' content='width=device-width, initial-scale=1'>"
     writeBS "<style type='text/css'>"
     writeBS indexStyle
     writeBS "</style></head><body>"


### PR DESCRIPTION
Adds viewport meta tag, now used by most front end developers by default