### PR TITLE
Correct the name of the One True Editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ programs. Key features include:
 [debug]: http://debug.elm-lang.org
 
 This means you can get a great development experience whether you are using
-Sublime Text, emacs, vim, or whatever else to edit Elm code.
+Sublime Text, Emacs, vim, or whatever else to edit Elm code.
 
 ## Install
 


### PR DESCRIPTION
The title basically says it all. It's Emacs, not emacs. :-)