### PR TITLE
Change watch extension from 'elm' to '.elm'

### DIFF
--- a/backend/Socket.hs
+++ b/backend/Socket.hs
@@ -17,7 +17,7 @@ fileChangeApp :: FilePath -> WS.ServerApp
 fileChangeApp watchedFile pendingConnection =
   do  connection <- WS.acceptRequest pendingConnection
       Notify.withManager $ \notifyManager ->
-        do  _ <- NDevel.treeExtExists notifyManager "." "elm" (sendHotSwap watchedFile connection)
+        do  _ <- NDevel.treeExtExists notifyManager "." ".elm" (sendHotSwap watchedFile connection)
             keepAlive connection
 
 


### PR DESCRIPTION
For me, this fixed the problem of automatic hot-swap not working on Linux (Ubuntu 15.04). 

Unfortunately, this does not fix hot-swap on MacOS (10.11). I was able to verify that this triggers `sendHotSwap`, but no data arrives through the WebSocket inside the browser.

See the 'hot-reload not working' part of #168.