### PR TITLE
Correctly display of Unicode characters

### DIFF
--- a/elm-reactor.cabal
+++ b/elm-reactor.cabal
@@ -62,6 +62,7 @@ Executable elm-reactor
     base >=4.2 && <5,
     blaze-html,
     blaze-markup,
+    utf8-string,
     bytestring,
     cmdargs,
     containers,

--- a/src/backend/Generate/Index.hs
+++ b/src/backend/Generate/Index.hs
@@ -5,7 +5,7 @@ module Generate.Index (toHtml, getInfo, getPkg) where
 import Control.Monad
 import Control.Monad.Except (ExceptT, liftIO, runExceptT, throwError)
 import Data.Aeson as Json
-import qualified Data.ByteString.Lazy.Char8 as LBSC
+import qualified Data.ByteString.Lazy.UTF8 as BSU8
 import qualified Data.List as List
 import qualified Data.Map as Map
 import qualified Data.Text as Text
@@ -77,7 +77,7 @@ toHtml info@(Info pwd _ _ _ _) =
   Help.makeHtml
     (List.intercalate "/" ("~" : pwd))
     ("/" ++ StaticFiles.indexPath)
-    ("Elm.Index.fullscreen(" ++ LBSC.unpack (Json.encode info) ++ ");")
+    ("Elm.Index.fullscreen(" ++ BSU8.toString (Json.encode info) ++ ");")
 
 
 


### PR DESCRIPTION
Greetings,

Unicode characters were not being properly encoded on the `reactor` index.

## Before
<img width="450" alt="utf8-before" src="https://cloud.githubusercontent.com/assets/49975/15205314/f082013a-17ca-11e6-9e58-840b3d56884a.png">
## After
<img width="450" alt="utf8-after" src="https://cloud.githubusercontent.com/assets/49975/15205372/81adf902-17cb-11e6-8c36-821bd44a7b4d.png">

