### PR TITLE
Fix build with non-utf8 locale

### DIFF
--- a/elm-reactor.cabal
+++ b/elm-reactor.cabal
@@ -73,7 +73,7 @@ Executable elm-reactor
     filepath,
     fsnotify >= 0.2,
     mtl,
-    process,
+    process-extras,
     snap-core,
     snap-server,
     template-haskell,

--- a/src/backend/StaticFiles/Build.hs
+++ b/src/backend/StaticFiles/Build.hs
@@ -5,11 +5,12 @@ module StaticFiles.Build
     where
 
 import qualified Data.ByteString as BS
+import Data.ByteString.Char8 (unpack)
 import System.Directory (removeFile)
 import System.Exit (ExitCode(..), exitFailure)
 import System.FilePath ((<.>), takeBaseName)
 import System.IO (hPutStrLn, stderr)
-import System.Process (readProcessWithExitCode)
+import System.Process.ByteString (readProcessWithExitCode)
 
 
 
@@ -34,12 +35,13 @@ elmMake source target =
           readProcessWithExitCode
               "elm-make"
               [ "--yes", source, "--output=" ++ target ]
-              ""
+              BS.empty
 
       case exitCode of
         ExitSuccess ->
           return ()
 
         ExitFailure _ ->
-          do  hPutStrLn stderr (unlines ["Failed to build " ++ source, "", out, err])
+          do  hPutStrLn stderr (unlines ["Failed to build " ++ source, "",
+                                         unpack out, unpack err])
               exitFailure


### PR DESCRIPTION
Had some issues building elm-reactor due to `LC_ALL=C`. This is standard behaviour for at least the paludis package manager, and possibly others. The changes in this PR should make the build process independent of locale.