### PR TITLE
Fix overflow and position CSS in Errors.elm

### DIFF
--- a/src/pages/Errors.elm
+++ b/src/pages/Errors.elm
@@ -50,14 +50,14 @@ view : Model -> Html msg
 view model =
   div
     [ style
-        [ "width" => "100%"
-        , "min-height" => "100%"
+        [ "min-height" => "100%"
         , "display" => "flex"
         , "flex-direction" => "column"
         , "align-items" => "center"
         , "background-color" => "black"
         , "color" => "rgb(233, 235, 235)"
         , "font-family" => "monospace"
+        , "overflow" => "auto"
         ]
     ]
     [ div
@@ -66,6 +66,8 @@ view model =
             , "white-space" => "pre"
             , "background-color" => "rgb(39, 40, 34)"
             , "padding" => "2em"
+            , "margin-left" => "auto"
+            , "margin-right" => "auto"
             ]
         ]
         (addColors model)


### PR DESCRIPTION
This fixes #206 . The problem was twofold:

1. The child div had a width that exceeds its parent, so it creates some new area of page that the parent doesn't (or rather can't) simply "auto-fill" to, resulting in partly white background. Fix: add "overflow: auto" to the parent, to bound the child within the parent.

2. The leftmost content could be cut off. This is due to some rules of Flexbox that I don't fully understand, but I was clued in by [this](http://stackoverflow.com/questions/33485841/top-gets-cut-off-when-using-flexbox) source to try adding  "margin-left/right: auto" rules to the flex child. That sounds like it'd be redundant in the presence of the "align-items: center" rule, but they do have an effect, and they fix the issue.

3. nit: There was a "width: 100%" rule on the outermost div, which was the inherited value anyway, so I removed it.

I found [this](https://www.impressivewebs.com/width-100-percent-css/) explanation helpful throughout while debugging/making these changes.

I was unable to test this change locally due to the build instructions not being update to date for 0.17 (or rather, the expando branch that the build instructions have one checkout is not able to be elm-make'd), but making these changes by hand in current elm-reactor fixes the issues.