### PR TITLE
Change `Basics.fst` to `Tuple.first`

### DIFF
--- a/src/pages/Index.elm
+++ b/src/pages/Index.elm
@@ -169,7 +169,7 @@ leftColumnView model =
         (
           div [ style <| boxHeaderStyles ++ blockStyles ] [ text "File Navigation" ]
           :: List.map folderDisplay (List.sort (List.filter (not << String.startsWith ".") model.dirs))
-          ++ List.map fileDisplay (List.sortBy fst (List.filter (not << String.startsWith "." << fst) model.files))
+          ++ List.map fileDisplay (List.sortBy Tuple.first (List.filter (not << String.startsWith "." << Tuple.first) model.files))
         )
 
     viewReadme markdown =


### PR DESCRIPTION
At Elm 0.18, `Basics.fst` changed to `Tuple.first` based on [Upgrading to 0.18](https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.18.md#renamed-functions-in-core)