### PR TITLE
Prevent error messages from overflowing to the left.

### DIFF
--- a/src/pages/Errors.elm
+++ b/src/pages/Errors.elm
@@ -53,7 +53,6 @@ view model =
         , "min-height" => "100%"
         , "display" => "flex"
         , "flex-direction" => "column"
-        , "align-items" => "center"
         , "background-color" => "black"
         , "color" => "rgb(233, 235, 235)"
         , "font-family" => "monospace"
@@ -65,6 +64,7 @@ view model =
             , "white-space" => "pre"
             , "background-color" => "rgb(39, 40, 34)"
             , "padding" => "2em"
+            , "margin" => "0 auto"
             ]
         ]
         (addColors model)


### PR DESCRIPTION
When tiling a text-editor next to elm-reactor the error message often gets pushed off the left side of the screen which makes it difficult to read.

This little patch keeps the centered alignment while preventing overflow on the left-hand side.

## Before:

![overflow-before](https://cloud.githubusercontent.com/assets/337811/23656919/99a5b1d6-0333-11e7-9e72-8c3b39352e0d.png)

## After:

![overflow-after](https://cloud.githubusercontent.com/assets/337811/23656936/b1c53520-0333-11e7-8c87-b0dcbe19c4e7.png)

( http://stackoverflow.com/a/33455342 explains the `margin: auto` trick, in case that's helpful )

Thanks!