### PR TITLE
Add feature: "add css links" #138

### DIFF
--- a/src/backend/Generate/Help.hs
+++ b/src/backend/Generate/Help.hs
@@ -5,14 +5,13 @@ module Generate.Help (makeHtml, makeCodeHtml, makeElmHtml) where
 import Text.Blaze.Html5 ((!))
 import qualified Text.Blaze.Html5 as H
 import qualified Text.Blaze.Html5.Attributes as A
-
-
+import Data.String (fromString)
 
 -- PAGES
 
 
-makeHtml :: String -> String -> String -> H.Html
-makeHtml title jsFile initCode =
+makeHtml :: String -> String -> String -> [String] -> H.Html
+makeHtml title jsFile initCode cssIncludes =
   H.docTypeHtml $ do
     H.head $ do
       H.meta ! A.charset "UTF-8"
@@ -22,11 +21,12 @@ makeHtml title jsFile initCode =
 
     H.body $ do
       H.script $ H.preEscapedToMarkup initCode
-      H.link
-        ! A.type_ "text/css"
-        ! A.rel "stylesheet"
-        ! A.href "https://fonts.googleapis.com/css?family=Source+Sans+Pro|Source+Code+Pro"
-
+      link' "https://fonts.googleapis.com/css?family=Source+Sans+Pro|Source+Code+Pro"
+      mapM_ link' cssIncludes
+  where link' css = H.link
+                  ! A.type_ "text/css"
+                  ! A.rel "stylesheet"
+                  ! A.href (fromString css)
 
 normalStyle :: H.Html
 normalStyle =
@@ -82,13 +82,14 @@ codeStyle =
 -- ELM CODE
 
 
-makeElmHtml :: FilePath -> H.Html
-makeElmHtml filePath =
+makeElmHtml :: FilePath -> [String] -> H.Html
+makeElmHtml filePath cssIncludes =
   H.docTypeHtml $ do
     H.head $ do
       H.meta ! A.charset "UTF-8"
       H.title $ H.toHtml ("~/" ++ filePath)
       H.style ! A.type_ "text/css" $ elmStyle
+      mapM_ link' cssIncludes
 
     H.body $ do
       H.div ! A.style waitingStyle $ do
@@ -103,6 +104,10 @@ makeElmHtml filePath =
       , "}"
       , "runElmProgram();"
       ]
+  where link' css = H.link
+                  ! A.type_ "text/css"
+                  ! A.rel "stylesheet"
+                  ! A.href (fromString css)
 
 
 elmStyle :: H.Html

--- a/src/backend/Generate/Index.hs
+++ b/src/backend/Generate/Index.hs
@@ -75,9 +75,10 @@ instance ToJSON PackageInfo where
 toHtml :: Info -> H.Html
 toHtml info@(Info pwd _ _ _ _) =
   Help.makeHtml
-    (List.intercalate "/" ("~" : pwd))
+    (List.intercalate "/" ("~" : pwd)) 
     ("/" ++ StaticFiles.indexPath)
     ("Elm.Index.fullscreen(" ++ BSU8.toString (Json.encode info) ++ ");")
+    []
 
 
 

--- a/src/backend/Generate/NotFound.hs
+++ b/src/backend/Generate/NotFound.hs
@@ -12,3 +12,4 @@ html =
     "Page Not Found"
     ("/" ++ StaticFiles.notFoundPath)
     "Elm.NotFound.fullscreen();"
+    []


### PR DESCRIPTION
- add a new flag -c/--cssincludes such that multiple css files can be added to your standard html via `elm-reactor -c "http://localhost:8000/static/mycss" -c "https://example.com/css/example.css"`

this is my first endeavour into elm land (though i am a long-time haskell user).

I created a new flag for elm-reactor to include (multiple) css files in the generated html when I view the app to some elm-file.

hope this fixes issue #138 - if there is something missing please tell me.